### PR TITLE
PEP 8 Explicitly State Variable Names convention? #535

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -914,11 +914,13 @@ older convention of prefixing such globals with an underscore (which
 you might want to do to indicate these globals are "module
 non-public").
 
-Function Names
+Function and variable names
 ~~~~~~~~~~~~~~
 
 Function names should be lowercase, with words separated by
 underscores as necessary to improve readability.
+
+Variable names follow the same convention as function names.
 
 mixedCase is allowed only in contexts where that's already the
 prevailing style (e.g. threading.py), to retain backwards


### PR DESCRIPTION
There is a response int StackOverflow to the question: [What is the naming convention in Python for variable and function names?](https://stackoverflow.com/questions/159720/what-is-the-naming-convention-in-python-for-variable-and-function-names). It says see PEP 8 and makes the statement "Use the function naming rules: lowercase with words separated by underscores as necessary to improve readability."

That statement is found in other sources and confirmed by experienced Python programmers. But, PEP 8 does not yet support that statement. 

 